### PR TITLE
Fixed syntac for default constructors according to latest spec update

### DIFF
--- a/source/ceylon/parse/grammar.ceylon
+++ b/source/ceylon/parse/grammar.ceylon
@@ -165,7 +165,7 @@ shared class Rule {
     shared actual Integer hash;
     shared AnyGrammar g;
 
-    shared new Rule(Function<Object,Nothing> consume,
+    shared new (Function<Object,Nothing> consume,
             ProductionClause[] consumes,
             Atom produces,
             Integer precedence,

--- a/source/ceylon/parse/state.ceylon
+++ b/source/ceylon/parse/state.ceylon
@@ -71,7 +71,7 @@ class EPState {
     variable Integer? _lsd = null;
 
     "Create a new initial EPState for the given start rule"
-    shared new EPState(Rule rule) {
+    shared new (Rule rule) {
         this.pos = 0;
         this.rule = rule;
         this.matchPos = 0;

--- a/source/ceylon/parse/typeAtomCache.ceylon
+++ b/source/ceylon/parse/typeAtomCache.ceylon
@@ -5,7 +5,7 @@ import ceylon.collection { HashMap, HashSet }
 shared class Atom {
     shared Integer val;
 
-    shared new Atom(Type t) {
+    shared new (Type t) {
         this.val = typeAtomCache.getAlias(t);
     }
 


### PR DESCRIPTION
just so that I could get rid of those pesky compiler errors
