### PR TITLE
Wrong equals() method in CeylonToken?

### DIFF
--- a/source/ceylon/parse/ceylon/CeylonToken.ceylon
+++ b/source/ceylon/parse/ceylon/CeylonToken.ceylon
@@ -11,8 +11,8 @@ shared class CeylonToken(shared String text, shared Integer line_start, shared
         if (type(other) != type(this)) { return false; }
         assert(is CeylonToken other);
 
-        return text == other.text && line_start == other.line_start && line_end
-            == other.line_end;
+        return line_start == other.line_start && line_end == other.line_end
+            && col_start == other.col_start && col_end == other.col_end;
     }
 }
 


### PR DESCRIPTION
Looks to me as the `equals()` method of `CeylonToken` is wrong. You wouldn't want to equal two tokens that are named the same and which are in the same line but in a different column position. Maybe you intented to write `text && line_start && col_start` instead of `text && line_start && line_end`. But I might be wrong...
