### PR TITLE
Improve build.properties to work in installed Ceylon

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -1,6 +1,10 @@
-dist.root.dir=${basedir}/../ceylon-dist
-dist.bin.dir=${dist.root.dir}/dist/bin
-dist.repo.dir=${dist.root.dir}/dist/repo
-dist.libs.dir=${dist.root.dir}/dist/lib
+# if Ceylon was built from source
+dist.root.dir=${basedir}/../ceylon-dist/dist
+# if Ceylon was installed from package
+dist.root.dir=/usr/share/ceylon/1.2.0
+
+dist.bin.dir=${dist.root.dir}/bin
+dist.repo.dir=${dist.root.dir}/repo
+dist.libs.dir=${dist.root.dir}/lib
   
 ceylon.ant.lib=${dist.libs.dir}/ceylon-ant.jar


### PR DESCRIPTION
/dist should be a part of the dist.root.dir, not the other dirs, since it's not present in the paths that the Ceylon packages install Ceylon into.
